### PR TITLE
Allows to preview private images

### DIFF
--- a/src/templates/_components/field/input.html
+++ b/src/templates/_components/field/input.html
@@ -1,4 +1,3 @@
-  
 {% import "_includes/forms" as forms %}
 
 {% set id = id ?? 'hotspot'~random() -%}
@@ -20,7 +19,7 @@
 {% set jsSettings = {
     id: id|namespaceInputId,
     asset: (asset is not null) ? {
-        url: asset.url,
+        url: craft.app.assets.thumbUrl(asset, asset.width, asset.height, false, false),
         width: asset.width,
         height: asset.height,
     } : null,


### PR DESCRIPTION
This PR allows to preview images that doesn't have a public URL (for instance, images on an AWS S3 private Bucket).

No Breaking Changes 😉